### PR TITLE
fix(path-typo): theme path typo fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
       {
         "label": "GitHub Blue",
         "uiTheme": "vs-dark",
-        "path": "./themes/gitHub-blue-color-theme.json"
+        "path": "./themes/github-blue-color-theme.json"
       }
     ]
   }


### PR DESCRIPTION
Extension was looking at: '.vscode/extensions/larxx.github-blue-1.0.4/themes/gitHub-blue-color-theme.json'

Tries to find file with gitHub instead of github (the h). It might work on windows since windows is not case sensitive as far as I know but It does not work on my linux machine.